### PR TITLE
Allow parsing of Open Graph metas without og:type present.

### DIFF
--- a/lib/Data/OpenGraph/Parser.pm
+++ b/lib/Data/OpenGraph/Parser.pm
@@ -58,7 +58,7 @@ sub parse_string {
         $content = $meta->attr('content');
         next unless $prop && $content;
         $prop =~ s/^og://;
-        if ($prop =~ /^$basictype:.+$/) {
+        if (defined($basictype) && $prop =~ /^$basictype:.+$/) {
             if (exists $properties{$prop}) {
                 if ((reftype($properties{$prop}) // '') eq 'ARRAY') {
                     push @{$properties{$prop}}, $content;

--- a/t/001_basic.t
+++ b/t/001_basic.t
@@ -25,4 +25,14 @@ EOM
     }
 };
 
+subtest 'nested-without-prefix' => sub {
+    my $og = Data::OpenGraph->parse_string(<<EOM);
+<meta property="og:type" content="audio">
+<meta property="audio:title" content="foo bar baz">
+EOM
+    if (not is $og->property("audio:title"), "foo bar baz") {
+        diag(Data::Dumper::Dumper($og));
+    }
+};
+
 done_testing;


### PR DESCRIPTION
This makes sure that Open Graph metas can be parsed even if `og:type` is not present. This fixes tests. I have also made some additional changes necessary to support both `HTML::TreeBuilder::LibXML` and `HTML::TreeBuilder::XPath`.